### PR TITLE
Tests: Reduce sleep timers

### DIFF
--- a/test/workhorse/enqueuer_test.rb
+++ b/test/workhorse/enqueuer_test.rb
@@ -32,7 +32,7 @@ class Workhorse::EnqueuerTest < WorkhorseTest
 
     w = Workhorse::Worker.new(queues: [:q1])
     w.start
-    sleep 1.5
+    sleep 1
     w.shutdown
 
     assert_equal 'succeeded', Workhorse::DbJob.first.state

--- a/test/workhorse/performer_test.rb
+++ b/test/workhorse/performer_test.rb
@@ -9,7 +9,7 @@ class Workhorse::WorkerTest < WorkhorseTest
       Workhorse::Enqueuer.enqueue DbConnectionTestJob.new
     end
     w.start
-    sleep 2
+    sleep 1
     w.shutdown
 
     assert_equal 5, DbConnectionTestJob.db_connections.count

--- a/test/workhorse/poller_test.rb
+++ b/test/workhorse/poller_test.rb
@@ -4,7 +4,7 @@ class Workhorse::PollerTest < WorkhorseTest
   def test_interruptable_sleep
     w = Workhorse::Worker.new(polling_interval: 60)
     w.start
-    sleep 2
+    sleep 0.5
 
     Timeout.timeout(1.5) do
       w.shutdown

--- a/test/workhorse/pool_test.rb
+++ b/test/workhorse/pool_test.rb
@@ -7,21 +7,21 @@ class Workhorse::PoolTest < WorkhorseTest
 
       4.times do |_i|
         p.post do
-          sleep 1
+          sleep 0.5
         end
       end
 
-      sleep 0.5
+      sleep 0.1
       assert_equal 1, p.idle
 
-      sleep 1
+      sleep 0.5
       assert_equal 5, p.idle
     end
   end
 
   def test_overflow
     with_pool 5 do |p|
-      5.times { p.post { sleep 1 } }
+      5.times { p.post { sleep 0.5 } }
 
       exception = assert_raises do
         p.post { sleep 1 }
@@ -37,23 +37,21 @@ class Workhorse::PoolTest < WorkhorseTest
 
       5.times do
         p.post do
-          sleep 1
           counter.increment
         end
       end
 
-      sleep 1.2
+      sleep 0.01
 
       assert_equal 5, counter.value
 
       2.times do
         p.post do
-          sleep 1
           counter.increment
         end
       end
 
-      sleep 1.2
+      sleep 0.01
 
       assert_equal 7, counter.value
     end


### PR DESCRIPTION
Reduce the sleep timers used in the unit tests. This reduces the test execution time from 31 to 13 seconds.

Before:
```
Finished in 31.262144s, 0.5438 runs/s, 1.3755 assertions/s.
```

After:
```
Finished in 12.538351s, 1.3558 runs/s, 3.4295 assertions/s.
```