### PR TITLE
Feature/nil queue

### DIFF
--- a/lib/workhorse/poller.rb
+++ b/lib/workhorse/poller.rb
@@ -99,10 +99,14 @@ module Workhorse
 
       # Restrict queues to "open" ones
       unless worker.queues.empty?
-        where = table[:queue].in(worker.queues.reject(&:nil?))
-
         if worker.queues.include?(nil)
-          where = where.or(table[:queue].eq(nil))
+          where = table[:queue].eq(nil)
+          remaining_queues = worker.queues.reject(&:nil?)
+          unless remaining_queues.empty?
+            where = where.or(table[:queue].in(remaining_queues))
+          end
+        else
+          where = table[:queue].in(worker.queues)
         end
 
         select = select.where(where)

--- a/lib/workhorse/poller.rb
+++ b/lib/workhorse/poller.rb
@@ -75,7 +75,7 @@ module Workhorse
       is_oracle = ActiveRecord::Base.connection.adapter_name == 'OracleEnhanced'
 
       # ---------------------------------------------------------------
-      # Lock all queued jobs that are not complete
+      # Lock all queued jobs that are waiting
       # ---------------------------------------------------------------
       Workhorse::DbJob.connection.execute(
         Workhorse::DbJob.select('null').where(
@@ -98,11 +98,13 @@ module Workhorse
       select = select.where(table[:queue].not_in(bad_queries_select))
 
       # Restrict queues to "open" ones
-      if worker.queues.any?
+      unless worker.queues.empty?
         where = table[:queue].in(worker.queues.reject(&:nil?))
+
         if worker.queues.include?(nil)
           where = where.or(table[:queue].eq(nil))
         end
+
         select = select.where(where)
       end
 

--- a/test/workhorse/worker_test.rb
+++ b/test/workhorse/worker_test.rb
@@ -87,6 +87,16 @@ class Workhorse::WorkerTest < WorkhorseTest
     assert_equal 'waiting',   jobs[2].state
   end
 
+  def test_nil_queue
+    enqueue_in_multiple_queues
+    work 1, queues: [nil]
+
+    jobs = Workhorse::DbJob.order(queue: :asc).to_a
+    assert_equal 'succeeded', jobs[0].state
+    assert_equal 'waiting',   jobs[1].state
+    assert_equal 'waiting',   jobs[2].state
+  end
+
   def test_queues_with_nil
     enqueue_in_multiple_queues
     work 3, queues: [nil, :q1]


### PR DESCRIPTION
The behavior of instantiating a Worker with only `[nil]` as queue was ill-defined; The worker would allow working on all unqueued jobs, as well as on the first queued job that appears in the results of the poller. This is of course unacceptable.

This set of commits aims at reducing any uncertainty regarding what queues are respected.