### PR TITLE
Defend tests against rogue workers

### DIFF
--- a/test/lib/test_helper.rb
+++ b/test/lib/test_helper.rb
@@ -20,6 +20,16 @@ class WorkhorseTest < ActiveSupport::TestCase
     sleep time
     w.shutdown
   end
+
+  def with_worker(options = {})
+    w = Workhorse::Worker.new(options)
+    begin
+      w.start
+      yield(w)
+    ensure
+      w.shutdown
+    end
+  end
 end
 
 ActiveRecord::Base.establish_connection adapter: 'mysql2', database: 'workhorse', username: 'travis', password: '', pool: 10, host: :localhost

--- a/test/lib/test_helper.rb
+++ b/test/lib/test_helper.rb
@@ -23,8 +23,8 @@ class WorkhorseTest < ActiveSupport::TestCase
 
   def with_worker(options = {})
     w = Workhorse::Worker.new(options)
+    w.start
     begin
-      w.start
       yield(w)
     ensure
       w.shutdown

--- a/test/workhorse/worker_test.rb
+++ b/test/workhorse/worker_test.rb
@@ -2,46 +2,41 @@ require 'test_helper'
 
 class Workhorse::WorkerTest < WorkhorseTest
   def test_idle
-    w = Workhorse::Worker.new(pool_size: 5, polling_interval: 1)
-    w.start
-    assert_equal 5, w.idle
+    with_worker(pool_size: 5, polling_interval: 1) do |w|
+      assert_equal 5, w.idle
 
-    sleep 0.5
+      sleep 0.5
+      Workhorse.enqueue BasicJob.new(sleep_time: 1)
 
-    Workhorse.enqueue BasicJob.new(sleep_time: 1)
+      sleep 1
+      assert_equal 4, w.idle
 
-    sleep 1
-    assert_equal 4, w.idle
-
-    sleep 1
-    assert_equal 5, w.idle
-
-    w.shutdown
+      sleep 1
+      assert_equal 5, w.idle
+    end
   end
 
   def test_start_and_shutdown
-    w = Workhorse::Worker.new
-    w.start
-    w.assert_state! :running
+    with_worker do |w|
+      w.assert_state! :running
 
-    assert_raises RuntimeError do
-      w.start
+      assert_raises RuntimeError do
+        w.start
+      end
+
+      w.shutdown
+      w.shutdown # Should be ignored
     end
-
-    w.shutdown
-    w.shutdown # Should be ignored
-
-    Workhorse.enqueue BasicJob.new
   end
 
   def test_perform
-    w = Workhorse::Worker.new polling_interval: 1
-    Workhorse.enqueue BasicJob.new(sleep_time: 0.1)
-    assert_equal 'waiting', Workhorse::DbJob.first.state
+    with_worker(polling_interval: 1) do
+      sleep 0.1
+      Workhorse.enqueue BasicJob.new(sleep_time: 0.1)
+      assert_equal 'waiting', Workhorse::DbJob.first.state
 
-    w.start
-    sleep 1
-    w.shutdown
+      sleep 1
+    end
 
     assert_equal 'succeeded', Workhorse::DbJob.first.state
   end
@@ -50,10 +45,7 @@ class Workhorse::WorkerTest < WorkhorseTest
     BasicJob.results.clear
 
     Workhorse.enqueue BasicJob.new(some_param: 5, sleep_time: 0)
-    w = Workhorse::Worker.new polling_interval: 1
-    w.start
-    sleep 0.5
-    w.shutdown
+    work 0.5
 
     assert_equal 'succeeded', Workhorse::DbJob.first.state
 
@@ -62,21 +54,19 @@ class Workhorse::WorkerTest < WorkhorseTest
   end
 
   def test_term
-    w = Workhorse::Worker.new
-    w.start
-    Process.kill 'TERM', Process.pid
-    sleep 1
-    w.assert_state! :shutdown
-    w.shutdown
+    with_worker do |w|
+      Process.kill 'TERM', Process.pid
+      sleep 1
+      w.assert_state! :shutdown
+    end
   end
 
   def test_int
-    w = Workhorse::Worker.new
-    w.start
-    Process.kill 'INT', Process.pid
-    sleep 1
-    w.assert_state! :shutdown
-    w.shutdown
+    with_worker do |w|
+      Process.kill 'INT', Process.pid
+      sleep 1
+      w.assert_state! :shutdown
+    end
   end
 
   def test_no_queues


### PR DESCRIPTION
When a test fails due to an assertion failure the execution of the rest
of the test is halted. This means that the shutdown method is not called
on the worker. Thus, all subsequent tests will have two workers that are
polling the database and posting jobs. This can lead to multiple
subsequent failures of completely unrelated tests, which is undesirable.

Fix this situation by providing tests with an environment with a worker
where the shutdown is ensured even in the case of a test failure,
isolating the unit tests from each other.