### PR TITLE
#16 Add API and doc for querying / resetting db jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ DbJob.failed
 ### Resetting jobs
 
 Jobs in a state other than `waiting` are either being processed or else already
-in a dead-end state such as `succeeded` and won't be performed again. Workhorse
+in a final state such as `succeeded` and won't be performed again. Workhorse
 provides an API method for resetting jobs in the following cases:
 
 * A job has succeeded or failed (states `succeeded` and `failed`) and needs to
@@ -315,7 +315,7 @@ provides an API method for resetting jobs in the following cases:
 * A job is stuck in state `locked` or `started` and the corresponding worker
   (check the database field `locked_by`) is not running anymore, i.e. due to a
   database connection loss or an unexpected worker crash. In these cases, the
-  job won't be processed ever and, if the job is in a queue, the entire queue is
+  job will never be processed, and, if the job is in a queue, the entire queue is
   considered to be locked and no further jobs will be processed in this queue.
 
   In these cases, make sure the worker is stopped and perform a forced reset:
@@ -324,7 +324,7 @@ provides an API method for resetting jobs in the following cases:
   db_job.reset!(true)
   ```
 
-Performing a reset will reset the job to state `waiting` and it will be
+Performing a reset will reset the job state to `waiting` and it will be
 processed again. All meta fields will be reset as well. See inline documentation
 of `Workhorse::DbJob#reset!` for more details.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,77 @@ Workhorse.setup do |config|
 end
 ```
 
+## Handling database jobs
+
+Jobs stored in the database can be accessed via the ActiveRecord model
+{Workhorse::DbJob}. This is the model representing a specific job database entry
+and is not to be confused with the actual job class you're enqueueing.
+
+### Obtaining database jobs
+
+DbJobs are returned to you when enqueuing new jobs:
+
+```ruby
+db_job = Workhorse.enqueue(MyJob.new)
+```
+
+You can also obtain a job via its ID that you either get from a returned job
+(see example above) or else by manually querying the database table:
+
+```ruby
+db_job = Workhorse::DbJob.find(42)
+```
+
+Note that database job objects reflect the job at the point in time when the
+database job object has been instantiated. To make sure you're looking at the
+latest job info, use the in-place `reload` method:
+
+```ruby
+db_job.reload
+```
+
+You can also retrieve a list of jobs in a specific state using one of the
+following methods:
+
+```ruby
+DbJob.waiting
+DbJob.locked
+DbJob.started
+DbJob.succeeded
+DbJob.failed
+```
+
+### Resetting jobs
+
+Jobs in a state other than `waiting` are either being processed or else already
+in a dead-end state such as `succeeded` and won't be performed again. Workhorse
+provides an API method for resetting jobs in the following cases:
+
+* A job has succeeded or failed (states `succeeded` and `failed`) and needs to
+  re-run. In these cases, perform a non-forced reset:
+
+  ```ruby
+  db_job.reset!
+  ```
+
+  This is always safe to do, even with workers running.
+
+* A job is stuck in state `locked` or `started` and the corresponding worker
+  (check the database field `locked_by`) is not running anymore, i.e. due to a
+  database connection loss or an unexpected worker crash. In these cases, the
+  job won't be processed ever and, if the job is in a queue, the entire queue is
+  considered to be locked and no further jobs will be processed in this queue.
+
+  In these cases, make sure the worker is stopped and perform a forced reset:
+
+  ```ruby
+  db_job.reset!(true)
+  ```
+
+Performing a reset will reset the job to state `waiting` and it will be
+processed again. All meta fields will be reset as well. See inline documentation
+of `Workhorse::DbJob#reset!` for more details.
+
 ## Frequently asked questions
 
 Please consult the [FAQ](FAQ.md).

--- a/lib/workhorse/db_job.rb
+++ b/lib/workhorse/db_job.rb
@@ -12,6 +12,58 @@ module Workhorse
 
     self.table_name = 'jobs'
 
+    def self.waiting
+      where(state: STATE_WAITING)
+    end
+
+    def self.locked
+      where(state: STATE_LOCKED)
+    end
+
+    def self.started
+      where(state: STATE_STARTED)
+    end
+
+    def self.succeeded
+      where(state: STATE_SUCCEEDED)
+    end
+
+    def self.failed
+      where(state: STATE_FAILED)
+    end
+
+    # Resets job to state "waiting" and clears all meta fields
+    # set by workhorse in course of processing this job.
+    #
+    # This is only allowed if the job is in a "dead-end-state" ("succeeded",
+    # "failed"), as it is safe to do so because workhorse won't touch these
+    # jobs. Set "force" to true in order to reset the job without checking for
+    # its state. If you do so, make sure that the job is not still being
+    # processed by a worker. If possible, shutdown all workers before performing
+    # a forced reset.
+    #
+    # After the job is reset, it will be performed again. If you reset a job
+    # that has already been performed ("succeeded") or partially performed
+    # ("failed"), make sure the actions performed in the job are repeatable or
+    # have been rolled back. E.g. if the job already wrote something to an
+    # external API, it may cause inconsistencies if the job is performed again.
+    def reset!(force = false)
+      unless force
+        assert_state! STATE_SUCCEEDED, STATE_FAILED
+      end
+
+      self.state = STATE_WAITING
+      self.locked_at = nil
+      self.locked_by = nil
+      self.started_at = nil
+      self.succeeded_at = nil
+      self.failed_at = nil
+      self.last_error = nil
+
+      save!
+    end
+
+    # @private Only to be used by workhorse
     def mark_locked!(worker_id)
       if changed?
         fail "Dirty jobs can't be locked."
@@ -27,6 +79,7 @@ module Workhorse
       save!
     end
 
+    # @private Only to be used by workhorse
     def mark_started!
       assert_state! STATE_LOCKED
 
@@ -35,6 +88,7 @@ module Workhorse
       save!
     end
 
+    # @private Only to be used by workhorse
     def mark_failed!(exception)
       assert_state! STATE_LOCKED, STATE_STARTED
 
@@ -44,6 +98,7 @@ module Workhorse
       save!
     end
 
+    # @private Only to be used by workhorse
     def mark_succeeded!
       assert_state! STATE_STARTED
 

--- a/lib/workhorse/db_job.rb
+++ b/lib/workhorse/db_job.rb
@@ -35,12 +35,12 @@ module Workhorse
     # Resets job to state "waiting" and clears all meta fields
     # set by workhorse in course of processing this job.
     #
-    # This is only allowed if the job is in a "dead-end-state" ("succeeded",
-    # "failed"), as it is safe to do so because workhorse won't touch these
-    # jobs. Set "force" to true in order to reset the job without checking for
-    # its state. If you do so, make sure that the job is not still being
-    # processed by a worker. If possible, shutdown all workers before performing
-    # a forced reset.
+    # This is only allowed if the job is in a final state ("succeeded" or
+    # "failed"), as only those jobs are safe to modify; workhorse will not touch
+    # these jobs. To reset a job without checking the state it is in, set
+    # "force" to true. Prior to doing so, ensure that the job is not still being
+    # processed by a worker. If possible, shut down all workers before
+    # performing a forced reset.
     #
     # After the job is reset, it will be performed again. If you reset a job
     # that has already been performed ("succeeded") or partially performed

--- a/test/workhorse/db_job_test.rb
+++ b/test/workhorse/db_job_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class Workhorse::DbJobTest < WorkhorseTest
+  def test_reset_succeeded
+    job = Workhorse.enqueue(BasicJob.new(sleep_time: 0))
+    work 0.5
+    job.reload
+    assert_equal 'succeeded', job.state
+
+    job.reset!
+
+    assert_clean job
+  end
+
+  def test_reset_failed
+    job = Workhorse.enqueue FailingTestJob
+    work 0.5
+    job.reload
+    assert_equal 'failed', job.state
+
+    job.reset!
+
+    assert_clean job
+  end
+
+  def test_reset_locked_unforced
+    job = Workhorse.enqueue(BasicJob.new(sleep_time: 0))
+    job.mark_locked!(42)
+
+    err = assert_raises do
+      job.reset!
+    end
+    assert_equal %(Job #{job.id} is not in state [:succeeded, :failed] but in state "locked".), err.message
+  end
+
+  def test_forced_reset
+    job = Workhorse.enqueue(BasicJob.new(sleep_time: 0))
+    job.mark_locked!(42)
+
+    assert_nothing_raised do
+      job.reset!(true)
+    end
+
+    assert_clean job
+  end
+
+  private
+
+  def assert_clean(job)
+    assert_equal 'waiting', job.state
+    assert_nil job.locked_by
+    assert_nil job.locked_at
+    assert_nil job.started_at
+    assert_nil job.failed_at
+    assert_nil job.succeeded_at
+    assert_nil job.last_error
+  end
+end


### PR DESCRIPTION
This adresses issue #16 and provides a way for querying database jobs in
specific states and resetting them back to state `waiting` using the
`reset!` method. The new method is covered by a new unit test.

The README gets a new section explaining how to obtain and manipulate
database jobs.