### PR TITLE
Daemon: store the pid as symlink target instead of file content

### DIFF
--- a/lib/workhorse/daemon.rb
+++ b/lib/workhorse/daemon.rb
@@ -131,7 +131,7 @@ module Workhorse
         $0 = process_name(worker)
         worker.block.call
       end
-      IO.write(pid_file_for(worker), pid)
+      File.symlink(pid.to_s, pid_file_for(worker))
     end
 
     def stop_worker(pid_file, pid, kill = false)
@@ -176,8 +176,8 @@ module Workhorse
     def read_pid(worker)
       file = pid_file_for(worker)
 
-      if File.exist?(file)
-        pid = IO.read(file).to_i
+      if File.symlink?(file)
+        pid = File.readlink(file).to_i
         return file, process?(pid) ? pid : nil
       else
         return nil, nil


### PR DESCRIPTION
Instead of writing the PID value into a file, a symlink could be used to _point_ to the PID. 

This has two benefits:
* PIDs of workers are evident by looking at the file itself
* No read/write of Files is necessary

So instead of having 
`workhorse.1.pid` with content `${pid}`
this will create a symlink 
`workhorse1.pid -> ${pid}`.
