### PR TITLE
Add retry-step to retry running the unit tests when they fail

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,6 +31,10 @@ jobs:
         sudo /etc/init.d/mysql start
         mysql -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }} -e 'CREATE DATABASE ${{ env.DB_DATABASE }};'
     - name: Run rake tests
-      run: bundle exec rake test TESTOPTS='--verbose'
+      uses: nick-fields/retry@v2
+      with:
+        timeout_seconds: 120
+        retry_on: error
+        command: bundle exec rake test TESTOPTS='--verbose'
     - name: Run rubocop
       run: bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         timeout_seconds: 120
         retry_on: error
+        max_attempts: 3
         command: bundle exec rake test TESTOPTS='--verbose'
     - name: Run rubocop
       run: bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Workhorse Changelog
 
+## 1.2.16 - 2023-08-28
+
+* Add `retry-step` to actions such that failed unit tests are executed again
+
+  Sitrox reference: #115888
+
 ## 1.2.15 - 2023-08-28
 
 * Add capability to skip transactions for enqueued RailsOps operations.


### PR DESCRIPTION
Add `retry-step` which re-runs the command in actions if it fails. Some tests might fail due to some timing issues, this re-runs the tests a certain number of times, which ensures such timing-issues cause the unittests to fail.