### PR TITLE
Fix Rubocop dependency on Ruby 2.5 & 2.6 CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.16 - 2023-09-18
 
-* Add support for `--skip_initializer` flag to install generator.
+* Add support for `--skip-initializer` flag to install generator.
 
   Sitrox reference: #114673.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ What it does not do:
 
    * A database migration for creating a table named `jobs`
    * The initializer `config/initializers/workhorse.rb` for global configuration
-     * This can be skipped using the `--skip_initializer` flag
+     * This can be skipped using the `--skip-initializer` flag
    * The daemon worker script `bin/workhorse.rb`
 
    Please customize the initializer and worker script to your liking.

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :gemspec do
 
     spec.add_development_dependency 'bundler'
     spec.add_development_dependency 'rake'
-    spec.add_development_dependency 'rubocop', '1.56.2'
+    spec.add_development_dependency 'rubocop', '~> 1.28.0' # Latest version supported with Ruby 2.5
     spec.add_development_dependency 'minitest'
     spec.add_development_dependency 'mysql2'
     spec.add_development_dependency 'colorize'

--- a/workhorse.gemspec
+++ b/workhorse.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   if s.respond_to? :add_runtime_dependency then
     s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
     s.add_development_dependency(%q<rake>.freeze, [">= 0"])
-    s.add_development_dependency(%q<rubocop>.freeze, ["= 1.56.2"])
+    s.add_development_dependency(%q<rubocop>.freeze, ["~> 1.28.0"])
     s.add_development_dependency(%q<minitest>.freeze, [">= 0"])
     s.add_development_dependency(%q<mysql2>.freeze, [">= 0"])
     s.add_development_dependency(%q<colorize>.freeze, [">= 0"])
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<bundler>.freeze, [">= 0"])
     s.add_dependency(%q<rake>.freeze, [">= 0"])
-    s.add_dependency(%q<rubocop>.freeze, ["= 1.56.2"])
+    s.add_dependency(%q<rubocop>.freeze, ["~> 1.28.0"])
     s.add_dependency(%q<minitest>.freeze, [">= 0"])
     s.add_dependency(%q<mysql2>.freeze, [">= 0"])
     s.add_dependency(%q<colorize>.freeze, [">= 0"])


### PR DESCRIPTION
This should fix the Rubocop dependecy resolve exception by limiting the Rubocop version to the latest supported version for Ruby 2.5 (https://docs.rubocop.org/rubocop/compatibility.html).

It also fixes the spelling to be more inline with other generator switches. Code adjustment wasn't necessary, since Rails automatically accepts both underline and dash separated words.