### PR TITLE
Make `config.clean_stuck_jobs` compatible with Ruby 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -180,17 +180,9 @@ Naming/BlockForwarding:
   Enabled: true
   EnforcedStyle: explicit
 
-# Don't require gemspec dependencies to be versioned. While it's generally a good
-# idea to require specifying versions of dependencies, we don't want to enforce it.
-Gemspec/DependencyVersion:
-  Enabled: false
-
 Style/HashSyntax:
   # Use `either` style for `EnforcedShorthandyntax` (see #106550)
   EnforcedShorthandSyntax: either
-
-Style/RedundantLineContinuation:
-  Enabled: false
 
 # Allow rescue 'Exception', necessary for Workhorse
 Lint/RescueException:

--- a/lib/workhorse/daemon.rb
+++ b/lib/workhorse/daemon.rb
@@ -150,10 +150,7 @@ module Workhorse
 
     def start_worker(worker)
       pid = fork do
-        # rubocop: disable Naming/VariableNumber
         $0 = process_name(worker)
-        # rubocop: enable Naming/VariableNumber
-
         # Reopen pipes to prevent #107576
         $stdin.reopen File.open('/dev/null', 'r')
         null_out = File.open '/dev/null', 'w'

--- a/lib/workhorse/poller.rb
+++ b/lib/workhorse/poller.rb
@@ -84,7 +84,7 @@ module Workhorse
           job_pids = rel.distinct.pluck(:locked_by_pid).to_set(&:to_i)
 
           # Get pids without active process
-          orphaned_pids = job_pids.filter do |pid|
+          orphaned_pids = job_pids.select do |pid|
             Process.getpgid(pid)
             false
           rescue Errno::ESRCH

--- a/lib/workhorse/poller.rb
+++ b/lib/workhorse/poller.rb
@@ -193,10 +193,7 @@ module Workhorse
     def poll
       @instant_repoll.make_false
 
-      # rubocop: disable Style/ComparableClamp
       timeout = [MIN_LOCK_TIMEOUT, [MAX_LOCK_TIMEOUT, worker.polling_interval].min].max
-      # rubocop: enable Style/ComparableClamp
-
       with_global_lock timeout: timeout do
         job_ids = []
 

--- a/test/lib/test_helper.rb
+++ b/test/lib/test_helper.rb
@@ -44,10 +44,10 @@ end
 
 ActiveRecord::Base.establish_connection(
   adapter:  'mysql2',
-  database: ENV['DB_NAME'] || 'workhorse',
-  username: ENV['DB_USERNAME'] || 'root',
-  password: ENV['DB_PASSWORD'] || '',
-  host:     ENV['DB_HOST'] || '127.0.0.1',
+  database: ENV.fetch('DB_NAME', nil) || 'workhorse',
+  username: ENV.fetch('DB_USERNAME', nil) || 'root',
+  password: ENV.fetch('DB_PASSWORD', nil) || '',
+  host:     ENV.fetch('DB_HOST', nil) || '127.0.0.1',
   pool:     10
 )
 


### PR DESCRIPTION
This PR fixes a compatibility issue with the `clean_stuck_jobs!` method added in e6f8516f with Ruby 2.5, where the `filter` method didn't exist yet for `Set`s as an alias to `select`.

Additionally unsupported rubocop cops have been removed from the `.rubocop.yml` file.