### PR TITLE
Fix rails environment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Workhorse Changelog
 
+## Unreleased - 2024-06-17
+
+* Fix rails environment check
+
+  Sitrox reference: #125593.
+
 ## 1.2.19 - 2024-05-07
 
 * Fix further compatibility issues with `ruby < 2.5`

--- a/lib/workhorse/daemon.rb
+++ b/lib/workhorse/daemon.rb
@@ -168,6 +168,8 @@ module Workhorse
     end
 
     def start_worker(worker)
+      check_rails_env if defined?(Rails)
+
       pid = fork do
         $0 = process_name(worker)
         # Reopen pipes to prevent #107576
@@ -243,6 +245,12 @@ module Workhorse
       end
 
       return file, pid, active
+    end
+
+    def check_rails_env
+      unless Rails.env.production?
+        warn 'WARNING: Always run workhorse workers in production environment. Other environments can lead to unexpected behavior.'
+      end
     end
   end
 end

--- a/lib/workhorse/worker.rb
+++ b/lib/workhorse/worker.rb
@@ -67,8 +67,6 @@ module Workhorse
       if instant_repolling
         @pool.on_idle { @poller.instant_repoll! }
       end
-
-      check_rails_env if defined?(Rails)
     end
 
     def log(text, level = :info)
@@ -194,12 +192,6 @@ module Workhorse
       mem = `ps -p #{pid} -o rss=`&.strip
       return nil if mem.blank?
       return mem.to_i / 1024
-    end
-
-    def check_rails_env
-      unless Rails.env.production?
-        warn 'WARNING: Always run workhorse workers in production environment. Other environments can lead to unexpected behavior.'
-      end
     end
 
     def trap_log_reopen


### PR DESCRIPTION
Move the rails environment check from the worker initialization to the daemon method `start_worker`. With this fix, the warning message that the production environment should be used at all times with `workhorse` is displayed again.