### PR TITLE
Add active record release to `create_table_jobs` migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Workhorse Changelog
 
+## Unreleased - 2024-07-02
+
+* Add active record release to `create_table_jobs` migration
+
+  Sitrox reference: #126612.
+
 ## 1.2.20 - 2024-06-17
 
 * Fix rails environment check

--- a/lib/generators/workhorse/templates/create_table_jobs.rb
+++ b/lib/generators/workhorse/templates/create_table_jobs.rb
@@ -1,4 +1,4 @@
-class CreateTableJobs < ActiveRecord::Migration
+class CreateTableJobs < ActiveRecord::Migration[7.1]
   def change
     create_table :jobs, force: true do |t|
       t.string :state, null: false, default: 'waiting'


### PR DESCRIPTION
Add the active record release to the class definition of the `create_table_jobs` migration template, such that the migration is generated correctly and does not need to be adapted manually.