### PR TITLE
Fix Github Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,7 +40,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           timeout_seconds: 120
-          retry_on: error
+          retry_on: any
           max_attempts: 3
           command: bundle exec rake test TESTOPTS='--verbose'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Workhorse Changelog
 
+## unreleased - 2024-07-08
+
+* Change `retry-on` in actions to `any`: also retry when the action hits a timeout
+
+* Comply with RuboCop
+
 ## 1.2.21 - 2024-07-02
 
 * Add active record release to `create_table_jobs` migration

--- a/lib/workhorse/performer.rb
+++ b/lib/workhorse/performer.rb
@@ -9,7 +9,7 @@ module Workhorse
     end
 
     def perform
-      begin
+      begin # rubocop:disable Style/RedundantBegin
         fail 'Performer can only run once.' if @started
         @started = true
         perform!
@@ -21,7 +21,7 @@ module Workhorse
     private
 
     def perform!
-      begin
+      begin # rubocop:disable Style/RedundantBegin
         Thread.current[:workhorse_current_performer] = self
 
         ActiveRecord::Base.connection_pool.with_connection do

--- a/lib/workhorse/poller.rb
+++ b/lib/workhorse/poller.rb
@@ -92,7 +92,7 @@ module Workhorse
 
           # Get pids without active process
           orphaned_pids = job_pids.select do |pid|
-            begin
+            begin # rubocop:disable Style/RedundantBegin
               Process.getpgid(pid)
               false
             rescue Errno::ESRCH
@@ -141,7 +141,7 @@ module Workhorse
     end
 
     def with_global_lock(name: :workhorse, timeout: 2, &_block)
-      begin
+      begin # rubocop:disable Style/RedundantBegin
         if @is_oracle
           result = Workhorse::DbJob.connection.select_all(
             "SELECT DBMS_LOCK.REQUEST(#{ORACLE_LOCK_HANDLE}, #{ORACLE_LOCK_MODE}, #{timeout}) FROM DUAL"
@@ -169,17 +169,17 @@ module Workhorse
             @max_global_lock_fails_reached = true
 
             worker.log 'Could not obtain global lock, retrying with next poll. ' \
-              'This will be the last such message for this worker until ' \
-              'the issue is resolved.', :warn
+                       'This will be the last such message for this worker until ' \
+                       'the issue is resolved.', :warn
 
             message = "Worker reached maximum number of consecutive times (#{Workhorse.max_global_lock_fails}) " \
-              "where the global lock could no be acquired within the specified timeout (#{timeout}). " \
-              'A worker that obtained this lock may have crashed without ending the database ' \
-              'connection properly. On MySQL, use "show processlist;" to see which connection(s) ' \
-              'is / are holding the lock for a long period of time and consider killing them using ' \
-              "MySQL's \"kill <Id>\" command. This message will be issued only once per worker " \
-              'and may only be re-triggered if the error happens again *after* the lock has ' \
-              'been solved in the meantime.'
+                      "where the global lock could no be acquired within the specified timeout (#{timeout}). " \
+                      'A worker that obtained this lock may have crashed without ending the database ' \
+                      'connection properly. On MySQL, use "show processlist;" to see which connection(s) ' \
+                      'is / are holding the lock for a long period of time and consider killing them using ' \
+                      "MySQL's \"kill <Id>\" command. This message will be issued only once per worker " \
+                      'and may only be re-triggered if the error happens again *after* the lock has ' \
+                      'been solved in the meantime.'
 
             worker.log message
             exception = StandardError.new(message)

--- a/lib/workhorse/pool.rb
+++ b/lib/workhorse/pool.rb
@@ -34,7 +34,7 @@ module Workhorse
         active_threads.increment
 
         @executor.post do
-          begin
+          begin # rubocop:disable Style/RedundantBegin
             yield
           ensure
             active_threads.decrement

--- a/lib/workhorse/worker.rb
+++ b/lib/workhorse/worker.rb
@@ -142,13 +142,13 @@ module Workhorse
     end
 
     def perform(db_job_id)
-      begin
+      begin # rubocop:disable Style/RedundantBegin
         mutex.synchronize do
           assert_state! :running
           log "Posting job #{db_job_id} to thread pool"
 
           @pool.post do
-            begin
+            begin # rubocop:disable Style/RedundantBegin
               Workhorse::Performer.new(db_job_id, self).perform
             rescue Exception => e
               log %(#{e.message}\n#{e.backtrace.join("\n")}), :error


### PR DESCRIPTION
- Make the code rubocop compliant such that the actions run again.
- Change the `retry_on` to `any` for the test action such that it will also be retried on a timeout.