### PR TITLE
Skip `at_exit` handlers again when exiting in ShellHandler while releasing lock file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 * Improve reliability of automated tests
 
+* Skip `at_exit` handlers again (as introduced in 1.2.22) when exiting in 
+  ShellHandler but still release lock file to fix issue originally fixed in 
+  1.2.23. This ensures compatibility with the `debug` gem, which would 
+  otherwise hang when using the Workhorse shell handler.
+
+  Sitrox reference: #128333.
+
 ## 1.2.24 - 2024-10-21
 
 * Fix compatibility with ActiveJob 7.2.x

--- a/lib/workhorse/daemon/shell_handler.rb
+++ b/lib/workhorse/daemon/shell_handler.rb
@@ -19,32 +19,32 @@ module Workhorse
       begin
         case ARGV.first
         when 'start'
-          exit daemon.start
+          status = daemon.start
         when 'stop'
-          exit daemon.stop
+          status = daemon.stop
         when 'kill'
-          exit daemon.stop(true)
+          status = daemon.stop(true)
         when 'status'
-          exit daemon.status
+          status = daemon.status
         when 'watch'
-          exit daemon.watch
+          status = daemon.watch
         when 'restart'
-          exit daemon.restart
+          status = daemon.restart
         when 'restart-logging'
-          exit daemon.restart_logging
+          status = daemon.restart_logging
         when 'usage'
           usage
-          exit 99
+          status = 0
         else
           usage
+          status = 99
         end
-
-        exit 0
       rescue StandardError => e
         warn "#{e.message}\n#{e.backtrace.join("\n")}"
-        exit 99
+        status = 99
       ensure
         lockfile&.flock(File::LOCK_UN)
+        exit! status
       end
     end
 


### PR DESCRIPTION
This reintroduces the fix from 1.2.22 when using the `debug` gem while also fixing the issue that the lock file was not released anymore originally fixed in 1.2.23.